### PR TITLE
Add StatsDClient hostname re-resolution and reconnection logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ targetCompatibility = 1.6
 
 dependencies {
     compile ("org.projectlombok:lombok:1.14.8")
+    compile("ch.qos.logback:logback-classic:1.1.7")
     testCompile("org.mockito:mockito-core:1.9.5")
     testCompile("org.springframework:spring-test:4.0.7.RELEASE")
     testCompile("org.testng:testng:6.8.8")

--- a/src/test/java/com/netuitive/ananke/statsd/client/NetuitiveStatsDClientTest.java
+++ b/src/test/java/com/netuitive/ananke/statsd/client/NetuitiveStatsDClientTest.java
@@ -11,26 +11,27 @@ import com.netuitive.ananke.statsd.client.request.TimedRequest;
 import com.netuitive.ananke.statsd.client.request.TimingRequest;
 import com.netuitive.ananke.statsd.entity.Status;
 import com.netuitive.ananke.statsd.entity.Tag;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
+
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
-import org.mockito.MockitoAnnotations;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 /**
  *
@@ -79,7 +80,7 @@ public class NetuitiveStatsDClientTest {
     @BeforeClass
     private void init() throws UnknownHostException{
         MockitoAnnotations.initMocks(this);
-        client = new NetuitiveStatsDClient(socket, InetAddress.getByName("127.0.0.1"), 8875);
+        client = new NetuitiveStatsDClient(socket, "127.0.0.1", 8875);
         argCaptor = ArgumentCaptor.forClass(DatagramPacket.class);
         
     }


### PR DESCRIPTION
Failed DNS hostname resolution currently prevents applications using the `NetuitiveStatsDClient` to fail during startup. These changes allow the client to retry connection while logging the DNS failures as warnings.

These changes also allow the `NetuitiveStatsDClient` to continue to function property when the underlying IP of a DNS entry changes.